### PR TITLE
feat: third party application management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,60 @@ Rails-based base tool engine integrates a variety of services
 
 ## Usage
 
+### Sms
 TBD...
+
+### IdVerification
+TBD...
+
+### Third-Party Application
+
+Save third-party application data to database, make the operation and maintenance easier, you can update the data directly and add a restart step to the service if necessary.
+
+1. New a model inheritance `BeanUtils::ThirdPartyApplication` (STI), like `BeanUtils::GoogleApplication`
+2. Define the attributes in your application model
+  * Normal attributes `application_attrs :api_base_uri`, this will generate these methods: `api_base_uri=`, `api_base_uri`
+  * Secret attributes `application_secret_attrs :api_key, :api_secret`, this will generate these methods: `api_key=`, `api_key`(Encrypted), `api_key_decryption`(Decrypted)
+3. Defining method like `api_config`, then you can use it where you want to use it.
+4. Make your Admin-end of this module.
+
+Example: using in your third-party request client.
+
+```ruby
+# models/bean_utils/google_application.rb
+def api_config
+ {
+   api_base_uri: api_base_uri,
+   api_key: api_key_decryption,
+   api_secret: api_secret_decryption,
+ }
+end
+```
+
+```ruby
+# lib/google/client.rb
+module Google
+  class Client
+    include HTTParty
+
+    class << self
+      def config
+        ::BeanUtils::GoogleApplication.first.api_config
+      end
+    end
+
+    def http_post()
+      post(path, body: body, headers: headers)
+    end
+
+    def headers
+      { api_key: Google::Client.config.dig(:api_key) }
+    end
+  end
+end
+
+Google::Client.base_uri Google::Client.config.dig(:api_base_uri)
+```
 
 ## Installation
 
@@ -14,7 +67,8 @@ Add this line to your application's Gemfile:
 2. Add this to your gemfile `gem 'bean_utils', path: 'engines/bean_utils'`
 3. Run `bundle install`
 4. Run `rake bean_utils:install:migrations` generate migrations
-5. Run `rake db:migrate`
+5. Delete the migrations files that are not needed for this project
+6. Run `rake db:migrate`
 
 ## Contributing
 Contribution directions go here.

--- a/app/models/bean_utils/id_card_verification.rb
+++ b/app/models/bean_utils/id_card_verification.rb
@@ -3,6 +3,8 @@ module BeanUtils
     include TencentCloudIdCardVerificationConcern
     include CloudServiceSecretConcern
 
+    service_secret_attributes "access_key", "access_secret"
+
     # acts_as_tenant(:application, class_name: "::Application", optional: true)
     belongs_to :application, class_name: "::Application", optional: true
 

--- a/app/models/bean_utils/sms.rb
+++ b/app/models/bean_utils/sms.rb
@@ -5,6 +5,8 @@ module BeanUtils
     include TencentCloudSmsConcern
     include CloudServiceSecretConcern
 
+    service_secret_attributes "access_key", "access_secret"
+
     # acts_as_tenant(:application, class_name: "::Application", optional: true)
     belongs_to :application, class_name: "::Application", optional: true
 

--- a/app/models/bean_utils/third_party_application.rb
+++ b/app/models/bean_utils/third_party_application.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module BeanUtils
+  class ThirdPartyApplication < ApplicationRecord
+    include DataEncryptConcern
+
+    # acts_as_tenant(:application, class_name: "::Application", optional: true)
+    belongs_to :application, class_name: "::Application", optional: true
+    validates_uniqueness_of :type, scope: :application_id
+
+    class << self
+      # usage: application_attrs :api_base_uri, :site, :oauth_redirect_url
+      def application_attrs(*attr_names)
+        attr_names.each do |attr_name|
+          define_method attr_name do
+            config.dig(attr_name.to_s) || config.dig(attr_name.to_sym)
+          end
+
+          define_method "#{attr_name}=" do |value|
+            config[attr_name] = value
+          end
+        end
+      end
+
+      # usage: application_secret_attrs :client_id, :client_secret, :map_api_key
+      def application_secret_attrs(*attr_names)
+        attr_names.each do |attr_name|
+          define_method attr_name do
+            config.dig(attr_name.to_s) || config.dig(attr_name.to_sym)
+          end
+
+          define_method "#{attr_name}=" do |value|
+            config[attr_name] = self.class.aes128_encrypt(value)
+          end
+
+          define_method "#{attr_name}_decryption" do
+            self.class.aes128_decrypt(self.public_send(attr_name))
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20230616082143_create_bean_utils_third_party_applications.rb
+++ b/db/migrate/20230616082143_create_bean_utils_third_party_applications.rb
@@ -1,0 +1,11 @@
+class CreateBeanUtilsThirdPartyApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bean_utils_third_party_applications do |t|
+      t.string :type
+      t.jsonb :config, default: {}
+      t.belongs_to :application
+
+      t.timestamps
+    end
+  end
+end

--- a/test/fixtures/bean_utils/third_party_applications.yml
+++ b/test/fixtures/bean_utils/third_party_applications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/bean_utils/third_party_application_test.rb
+++ b/test/models/bean_utils/third_party_application_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module BeanUtils
+  class ThirdPartyApplicationTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
第三方应用管理，例如google，line等等，存储第三方应用的key到数据库中。
1. 避免更新帐号、部署生产时需要修改代码
2. 这类信息一般存在 credentials 中，MR不容易检查，降低失误的概率

[readme 更新预览](https://github.com/beansmile/bean_utils/tree/feat-third-party-application)